### PR TITLE
feat: add make extract_translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ coverage.xml
 
 # Translations
 *.mo
+animation/conf/locale/*/LC_MESSAGES/*
 
 # Mr Developer
 .mr.developer.cfg

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ PIP_COMPILE_OPTS = -v
 
 PIP_COMPILE = pip-compile --upgrade $(PIP_COMPILE_OPTS)
 
+WORKING_DIR := animation
+EXTRACT_DIR := $(WORKING_DIR)/conf/locale/en/LC_MESSAGES
+EXTRACTED_DJANGO := $(EXTRACT_DIR)/django-partial.po
+EXTRACTED_TEXT := $(EXTRACT_DIR)/django.po
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q -r requirements/pip_tools.txt
@@ -15,3 +20,9 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 
 requirements: ## install development environment requirements
 	pip install -r requirements/base.txt
+
+extract_translations: ## extract strings to be translated, outputting .po files
+	cd $(WORKING_DIR) && i18n_tool extract
+	mv $(EXTRACTED_DJANGO) $(EXTRACTED_TEXT)
+	sed -i'' -e 's/nplurals=INTEGER/nplurals=2/' $(EXTRACTED_TEXT)
+	sed -i'' -e 's/plural=EXPRESSION/plural=\(n != 1\)/' $(EXTRACTED_TEXT)

--- a/animation/animation.py
+++ b/animation/animation.py
@@ -158,7 +158,7 @@ With the gaps between the pins aligned with the shear line, the plug (yellow) ca
     ## effectively a TODO. 
 
     display_name = String(
-        default="Completion", scope=Scope.settings,
+        default="Animation", scope=Scope.settings,
         help=_("Display name")
     )
 

--- a/animation/animation.py
+++ b/animation/animation.py
@@ -10,6 +10,13 @@ from xblock.fields import DateTime, Float, Integer, List, Scope, String
 from xblock.fragment import Fragment
 
 
+def _(text):
+    """
+    Make '_' a no-op, so we can scrape strings
+    """
+    return text
+
+
 class AnimationXBlock(XBlock):
     """
     TO-DO: document what your XBlock does.
@@ -22,33 +29,33 @@ class AnimationXBlock(XBlock):
     animation = List(
         default=[], 
         scope=Scope.settings,
-        help="Animation",
+        help=_("Animation"),
     )
 
     height = Integer(
         scope=Scope.settings,
-        help="Height"
+        help=_("Height")
         )
 
     textheight = Integer(
         scope=Scope.settings,
-        help="Text Height"
+        help=_("Text Height")
         )
 
     width = Integer(
         scope=Scope.settings,
-        help="Width"
+        help=_("Width")
         )
 
     position = Integer(
         scope=Scope.user_state,
-        help="Current position",
+        help=_("Current position"),
         default=0
     )
 
     max_position = Integer(
         scope=Scope.user_state,
-        help="Maximum position (for progress)",
+        help=_("Maximum position (for progress)"),
         default=0
     )
 
@@ -152,24 +159,26 @@ With the gaps between the pins aligned with the shear line, the plug (yellow) ca
 
     display_name = String(
         default="Completion", scope=Scope.settings,
-        help="Display name"
+        help=_("Display name")
     )
 
     start = DateTime(
         default=None, scope=Scope.settings,
-        help="ISO-8601 formatted string representing the start date of this assignment. We ignore this."
+        help=_("ISO-8601 formatted string representing the start date of this assignment. We ignore this.")
     )
 
     due = DateTime(
         default=None, scope=Scope.settings,
-        help="ISO-8601 formatted string representing the due date of this assignment. We ignore this."
+        help=_("ISO-8601 formatted string representing the due date of this assignment. We ignore this.")
     )
 
     weight = Float(
         display_name="Problem Weight",
-        help=("Defines the number of points each problem is worth. "
-              "If the value is not set, the problem is worth the sum of the "
-              "option point values."),
+        help=_(
+            "Defines the number of points each problem is worth. "
+            "If the value is not set, the problem is worth the sum of the "
+            "option point values."
+        ),
         values={"min": 0, "step": .1},
         scope=Scope.settings
     )

--- a/animation/conf/locale/config.yaml
+++ b/animation/conf/locale/config.yaml
@@ -1,0 +1,4 @@
+# Configuration for i18n workflow.
+
+locales:
+    - en  # English - Source Language


### PR DESCRIPTION
feat: add make extract_translations

- [ ] Tested on local devstack palm to ensure that everything renders fine
- [x] ~~Tested on local devstack palm to ensure that local translation still works~~ no local translation exists in this repo

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes

**For XBlocks:**
 - The standard translation path must be `conf/locale`. Therefore, we are creating a link from `conf/locale` to `translations` so Atlas can find the path without disrupting the current way of having translations locally within the XBlocks
 - [openedx-translations](https://github.com/openedx/openedx-translations) will have a related PR that adds the XBlock to the pipeline. This will not affect the current way of managing/updating translations
 - At the end of the project, a clear change log will be added and all translations will be handled by Atlas. Thus, the local translation will be removed from the repo within the version bump
 - A notification for the community will be published to ensure that everyone knows why translations directories are removed from all repos